### PR TITLE
Fixed finding ts source files in path.js

### DIFF
--- a/App/tasks/paths.js
+++ b/App/tasks/paths.js
@@ -53,7 +53,7 @@ module.exports = {
 
     ts: {
         path: root,
-        sources: [root + 'app.ts', root + 'constants/**/.ts', root + 'modules/**/.ts'],
+        sources: [root + 'app.ts', root + 'constants/**/*.ts', root + 'modules/**/*.ts'],
         tsd: root + 'tsd.json',
         tsconfig: root + 'tsconfig.json'
     }


### PR DESCRIPTION
Gulp watch didn't work because ts files weren't enumerated properly.